### PR TITLE
Allow the release namespace to be overridden

### DIFF
--- a/infra/helm_chart/Chart.yaml
+++ b/infra/helm_chart/Chart.yaml
@@ -1,6 +1,9 @@
 apiVersion: v2
 name: pod-restarter
-description: A Helm chart for Kubernetes
+description: A Helm chart for pod-restarter
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.5"
+maintainers:
+  - name: andreistefanciprian
+    email: andreistefanciprian@gmail.com

--- a/infra/helm_chart/templates/_helpers.tpl
+++ b/infra/helm_chart/templates/_helpers.tpl
@@ -59,3 +59,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "pod_restarter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/infra/helm_chart/templates/clusterrole_binding.yaml
+++ b/infra/helm_chart/templates/clusterrole_binding.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "pod_restarter.fullname" . }}
-  namespace: {{ include "pod_restarter.fullname" . }}
+  namespace: {{ template "pod_restarter.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: {{ include "pod_restarter.fullname" . }}

--- a/infra/helm_chart/templates/deployment.yaml
+++ b/infra/helm_chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "pod_restarter.fullname" . }}
+  namespace: {{ template "pod_restarter.namespace" . }}
   labels:
     {{- include "pod_restarter.labels" . | nindent 4 }}
 spec:

--- a/infra/helm_chart/templates/namespace.yaml
+++ b/infra/helm_chart/templates/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "pod_restarter.fullname" . }}
-  labels:
-    {{- include "pod_restarter.labels" . | nindent 4 }}

--- a/infra/helm_chart/templates/serviceaccount.yaml
+++ b/infra/helm_chart/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pod_restarter.fullname" . }}
+  namespace: {{ template "pod_restarter.namespace" . }}
   labels:
     {{- include "pod_restarter.labels" . | nindent 4 }}
 {{- end }}

--- a/infra/helm_chart/values.yaml
+++ b/infra/helm_chart/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+nameOverride: ""
+namespaceOverride: ""
+
 podRestarter:
   eventReason: "BackOff"
   # eventMessage: 'Failed to pull image "wrongimage"'


### PR DESCRIPTION
Useful when over writing the namespace from helm cli.
e.g.: `helm template --namespace flux-system infra/helm_chart`